### PR TITLE
[7.3.1] Change CPU request to 4

### DIFF
--- a/kubernetes/eks/fortisoar-statefulset.yaml
+++ b/kubernetes/eks/fortisoar-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
         resources:
           requests:
             memory: "16Gi"
-            cpu: "8.0"
+            cpu: "4.0"
           limits:                              
             memory: "32Gi"
             cpu: "8.0"


### PR DESCRIPTION
ticket: https://mantis.fortinet.com/bug_view_page.php?bug_id=0869835
changes made:
1. t2.2xlarge instance type have 32GB and 8 CPU. But if other than FortiSOAR pod runs on the node, FortiSOAR pod fails with error '0/1 nodes are available: 1 Insufficient cpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.
'.
Hence make requests to 4CPU. Previously it was 8. This is minimal resources required, else pod doesn't come up. 
unit test:
1. Deploy FortiSOAR statefulset on t2.2xlarge instance type.