### PR TITLE
[7.3.1] Change the EKS components names from 'fortisoar' to 'fsr'

### DIFF
--- a/kubernetes/eks/README
+++ b/kubernetes/eks/README
@@ -11,16 +11,16 @@
  #kubectl apply -f fortisoar-pvc.yaml
  
  It creates below PVC.
- /data                  (fortisoar-pvc-data 15GB)
- /var/lib/rabbitmq      (fortisoar-pvc-rabbitmq 15GB)
- /var/lib/elasticsearch (fortisoar-pvc-elasticsearch 40GB)
- /var/lib/pgsql         (fortisoar-pvc-pgsql 150GB)
- /var/log               (fortisoar-pvc-log 5GB)
- /home/csadmin          (fortisoar-pvc-home-csadmin 20GB)
- /opt/cyops/configs     (fortisoar-pvc-configs 15GB)
+ /data                  (fsr-pvc-data 15GB)
+ /var/lib/rabbitmq      (fsr-pvc-rabbitmq 15GB)
+ /var/lib/elasticsearch (fsr-pvc-elasticsearch 40GB)
+ /var/lib/pgsql         (fsr-pvc-pgsql 150GB)
+ /var/log               (fsr-pvc-log 5GB)
+ /home/csadmin          (fsr-pvc-home-csadmin 20GB)
+ /opt/cyops/configs     (fsr-pvc-configs 15GB)
 
 5. Note down the load balancer name created by service.
- #kubectl get svc -n fortisoar -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}"
+ #kubectl get svc -n fsr -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}"
 
 6. Before creating statefulset, do below:
   1. Update the repository hostname placeholder. Note that even if you do not have private repository set,
@@ -30,11 +30,12 @@
 
   2. Update the load balancer hostname placeholder with value got from previous step. Below is example name.
 
-     sed -i 's#@PLACEHOLDER_HOSTNAME_LOAD_BALANCER@#k8s-fortisoa-fortisoa-b6fc340816-<account-id-here>.elb.ap-south-1.amazonaws.com#g' fortisoar-statefulset.yaml
+     sed -i 's#@PLACEHOLDER_HOSTNAME_LOAD_BALANCER@#k8s-fsr-fsr-xxxxxxxxxx-xxxxxxxxxxxxxxxx.elb.<region-code-here>.amazonaws.com#g' fortisoar-statefulset.yaml
+ 
 
   3. Update the docker image placeholder with the docker image path. Below is example path.
 
-     sed -i 's#@PLACEHOLDER_DOCKER_IMAGE@#<account-id-here>.dkr.ecr.ap-south-1.amazonaws.com/fortisoar/fortisoar:7.3.1#g' fortisoar-statefulset.yaml
+     sed -i 's#@PLACEHOLDER_DOCKER_IMAGE@#<account-id-here>.dkr.ecr.<region-code-here>.amazonaws.com/fortisoar/fortisoar:7.3.1#g' fortisoar-statefulset.yaml
 
 7. Create statefulset.
  #kubectl apply -f fortisoar-statefulset.yaml

--- a/kubernetes/eks/fortisoar-namespace.yaml
+++ b/kubernetes/eks/fortisoar-namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: fortisoar
+  name: fsr
   labels:
-    app: fortisoar
+    app: fsr

--- a/kubernetes/eks/fortisoar-pvc.yaml
+++ b/kubernetes/eks/fortisoar-pvc.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: fortisoar-pvc-data
-  namespace: fortisoar
+  name: fsr-pvc-data
+  namespace: fsr
   labels:
-    app: fortisoar
+    app: fsr
 spec:
   accessModes:
    - ReadWriteOnce
-  storageClassName: fortisoar-storageclass-ebs
+  storageClassName: fsr-storageclass-ebs
   resources:
    requests:
     storage: 15Gi
@@ -16,14 +16,14 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: fortisoar-pvc-rabbitmq
-  namespace: fortisoar
+  name: fsr-pvc-rabbitmq
+  namespace: fsr
   labels:
-    app: fortisoar
+    app: fsr
 spec:
   accessModes:
    - ReadWriteOnce
-  storageClassName: fortisoar-storageclass-ebs
+  storageClassName: fsr-storageclass-ebs
   resources:
    requests:
     storage: 15Gi
@@ -31,14 +31,14 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: fortisoar-pvc-elasticsearch
-  namespace: fortisoar
+  name: fsr-pvc-elasticsearch
+  namespace: fsr
   labels:
-    app: fortisoar
+    app: fsr
 spec:
   accessModes:
    - ReadWriteOnce
-  storageClassName: fortisoar-storageclass-ebs
+  storageClassName: fsr-storageclass-ebs
   resources:
    requests:
     storage: 40Gi
@@ -46,14 +46,14 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: fortisoar-pvc-pgsql
-  namespace: fortisoar
+  name: fsr-pvc-pgsql
+  namespace: fsr
   labels:
-    app: fortisoar
+    app: fsr
 spec:
   accessModes:
    - ReadWriteOnce
-  storageClassName: fortisoar-storageclass-ebs
+  storageClassName: fsr-storageclass-ebs
   resources:
    requests:
     storage: 150Gi
@@ -61,14 +61,14 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: fortisoar-pvc-log
-  namespace: fortisoar
+  name: fsr-pvc-log
+  namespace: fsr
   labels:
-    app: fortisoar
+    app: fsr
 spec:
   accessModes:
    - ReadWriteOnce
-  storageClassName: fortisoar-storageclass-ebs
+  storageClassName: fsr-storageclass-ebs
   resources:
    requests:
     storage: 5Gi
@@ -76,14 +76,14 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: fortisoar-pvc-home-csadmin
-  namespace: fortisoar
+  name: fsr-pvc-home-csadmin
+  namespace: fsr
   labels:
-    app: fortisoar
+    app: fsr
 spec:
   accessModes:
    - ReadWriteOnce
-  storageClassName: fortisoar-storageclass-ebs
+  storageClassName: fsr-storageclass-ebs
   resources:
    requests:
     storage: 20Gi
@@ -91,14 +91,14 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: fortisoar-pvc-configs
-  namespace: fortisoar
+  name: fsr-pvc-configs
+  namespace: fsr
   labels:
-    app: fortisoar
+    app: fsr
 spec:
   accessModes:
    - ReadWriteOnce
-  storageClassName: fortisoar-storageclass-ebs
+  storageClassName: fsr-storageclass-ebs
   resources:
    requests:
     storage: 15Gi

--- a/kubernetes/eks/fortisoar-service.yaml
+++ b/kubernetes/eks/fortisoar-service.yaml
@@ -1,17 +1,17 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: fortisoar
-  namespace: fortisoar
+  name: fsr
+  namespace: fsr
   labels:
-    app: fortisoar
+    app: fsr
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: external
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true
 spec:
   selector:
-    app: fortisoar
+    app: fsr
   type: LoadBalancer
   ports:
   - name: port-https

--- a/kubernetes/eks/fortisoar-statefulset.yaml
+++ b/kubernetes/eks/fortisoar-statefulset.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: fortisoar
-  namespace: fortisoar
+  name: fsr
+  namespace: fsr
   labels:
-    app: fortisoar
+    app: fsr
 spec:
   selector:
     matchLabels:
-      app: fortisoar
-  serviceName: fortisoar
+      app: fsr
+  serviceName: fsr
   replicas: 1
   template:
     metadata:
       labels:
-        app: fortisoar
+        app: fsr
     spec:
       # Uncomment 'hostAliases' section if the repository hostname is not DNS resolvable.
       # Make sure you update the IP to the correct value.
@@ -27,47 +27,47 @@ spec:
           - name: ndots
             value: "1"  
       initContainers:
-      - name: fortisoar-init
+      - name: fsr-init
         image: @PLACEHOLDER_DOCKER_IMAGE@
         imagePullPolicy: Always
         command: ["/opt/cyops/scripts/kubernetes/init-container.sh"]
         volumeMounts:
           - mountPath: /var/lib/rabbitmq-init
-            name: fortisoar-v-rabbitmq
+            name: fsr-v-rabbitmq
           - mountPath: /var/lib/elasticsearch-init
-            name: fortisoar-v-elasticsearch
+            name: fsr-v-elasticsearch
           - mountPath: /var/lib/pgsql-init
-            name: fortisoar-v-pgsql
+            name: fsr-v-pgsql
           - mountPath: /var/log-init
-            name: fortisoar-v-log
+            name: fsr-v-log
           - mountPath: /home/csadmin-init
-            name: fortisoar-v-home-csadmin
+            name: fsr-v-home-csadmin
           - mountPath: /opt/cyops/configs-init
-            name: fortisoar-v-configs
+            name: fsr-v-configs
       volumes:
-      - name: fortisoar-v-data
+      - name: fsr-v-data
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-data
-      - name: fortisoar-v-rabbitmq
+          claimName: fsr-pvc-data
+      - name: fsr-v-rabbitmq
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-rabbitmq
-      - name: fortisoar-v-elasticsearch
+          claimName: fsr-pvc-rabbitmq
+      - name: fsr-v-elasticsearch
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-elasticsearch
-      - name: fortisoar-v-pgsql
+          claimName: fsr-pvc-elasticsearch
+      - name: fsr-v-pgsql
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-pgsql
-      - name: fortisoar-v-log
+          claimName: fsr-pvc-pgsql
+      - name: fsr-v-log
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-log
-      - name: fortisoar-v-home-csadmin
+          claimName: fsr-pvc-log
+      - name: fsr-v-home-csadmin
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-home-csadmin
-      - name: fortisoar-v-configs
+          claimName: fsr-pvc-home-csadmin
+      - name: fsr-v-configs
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-configs  
+          claimName: fsr-pvc-configs  
       containers:
-      - name: fortisoar
+      - name: fsr
         image: @PLACEHOLDER_DOCKER_IMAGE@
         imagePullPolicy: Always
         command: ["/usr/sbin/init"]
@@ -109,19 +109,19 @@ spec:
             name: cgroup
             readOnly: true
           - mountPath: /data
-            name: fortisoar-v-data
+            name: fsr-v-data
           - mountPath: /var/lib/rabbitmq
-            name: fortisoar-v-rabbitmq
+            name: fsr-v-rabbitmq
           - mountPath: /var/lib/elasticsearch
-            name: fortisoar-v-elasticsearch
+            name: fsr-v-elasticsearch
           - mountPath: /var/lib/pgsql
-            name: fortisoar-v-pgsql
+            name: fsr-v-pgsql
           - mountPath: /var/log
-            name: fortisoar-v-log
+            name: fsr-v-log
           - mountPath: /home/csadmin
-            name: fortisoar-v-home-csadmin
+            name: fsr-v-home-csadmin
           - mountPath: /opt/cyops/configs
-            name: fortisoar-v-configs
+            name: fsr-v-configs
         ports:
         - name: port-https
           containerPort: 443
@@ -145,24 +145,24 @@ spec:
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup
-      - name: fortisoar-v-data
+      - name: fsr-v-data
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-data
-      - name: fortisoar-v-rabbitmq
+          claimName: fsr-pvc-data
+      - name: fsr-v-rabbitmq
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-rabbitmq
-      - name: fortisoar-v-elasticsearch
+          claimName: fsr-pvc-rabbitmq
+      - name: fsr-v-elasticsearch
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-elasticsearch
-      - name: fortisoar-v-pgsql
+          claimName: fsr-pvc-elasticsearch
+      - name: fsr-v-pgsql
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-pgsql
-      - name: fortisoar-v-log
+          claimName: fsr-pvc-pgsql
+      - name: fsr-v-log
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-log
-      - name: fortisoar-v-home-csadmin
+          claimName: fsr-pvc-log
+      - name: fsr-v-home-csadmin
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-home-csadmin
-      - name: fortisoar-v-configs
+          claimName: fsr-pvc-home-csadmin
+      - name: fsr-v-configs
         persistentVolumeClaim:
-          claimName: fortisoar-pvc-configs
+          claimName: fsr-pvc-configs

--- a/kubernetes/eks/fortisoar-storageclass.yaml
+++ b/kubernetes/eks/fortisoar-storageclass.yaml
@@ -1,7 +1,7 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: fortisoar-storageclass-ebs
+  name: fsr-storageclass-ebs
 provisioner: ebs.csi.aws.com
 reclaimPolicy: Retain
 allowVolumeExpansion: true


### PR DESCRIPTION
ticket: https://mantis.fortinet.com/bug_view_page.php?bug_id=0870283
changes made:
1. Update the namespace name as 'fsr' and all the K8s component to use 'fsr' instead of 'fortisoar' full word.
2. DNS record for load balancer is getting created as below for 'fortisoar' word.

k8s-fortisoa-fortisoa-e7179ea3e0-b281e5da96c67d81.elb.us-west-2.amazonaws.com

Please note that missing 'r'. It taking only first 8 characters. I did not find any documentation around its taking only first 8 characters, but looking at the various blogs of AWS, its seems so. Use word 'fsr', so that it will convey better that 'fortisoa'.