### PR TITLE
[7.3.1] Make sure persistent volumes gets created in same availability zone as of pod

### DIFF
--- a/kubernetes/eks/fortisoar-storageclass.yaml
+++ b/kubernetes/eks/fortisoar-storageclass.yaml
@@ -5,7 +5,7 @@ metadata:
 provisioner: ebs.csi.aws.com
 reclaimPolicy: Retain
 allowVolumeExpansion: true
-volumeBindingMode: Immediate # Can be set as WaitForFirstConsumer
+volumeBindingMode: WaitForFirstConsumer
 parameters:
   type: gp2
   fsType: ext4 


### PR DESCRIPTION
ticket: https://mantis.fortinet.com/bug_view_page.php?bug_id=0870109
changes made:

The Immediate mode indicates that volume binding and dynamic provisioning occurs once the PersistentVolumeClaim is created. For storage backends that are topology-constrained and not globally accessible from all Nodes in the cluster, PersistentVolumes will be bound or provisioned without knowledge of the Pod's scheduling requirements. This may result in unschedulable Pods.

A cluster administrator can address this issue by specifying the WaitForFirstConsumer mode which will delay the binding and provisioning of a PersistentVolume until a Pod using the PersistentVolumeClaim is created. PersistentVolumes will be selected or provisioned conforming to the topology that is specified by the Pod's scheduling constraints. These include, but are not limited to, resource requirements, node selectors, pod affinity and anti-affinity, and taints and tolerations.

ref https://kubernetes.io/docs/concepts/storage/storage-classes/

In addition to above, We need to make sure below:
The node group in EKS should not cross availability zone.